### PR TITLE
Add partial Python CFDP utilities

### DIFF
--- a/python_cfdp/README.md
+++ b/python_cfdp/README.md
@@ -1,0 +1,6 @@
+# Python CFDP Utilities
+
+This directory contains a minimal Python translation of a few classes from the
+Java CFDP module.  Only the helper routines in `common` have been ported as an
+example.  The full CFDP implementation available under `eu.dariolucia.ccsds.cfdp`
+contains many additional classes which are not yet provided in Python.

--- a/python_cfdp/__init__.py
+++ b/python_cfdp/__init__.py
@@ -1,0 +1,1 @@
+"""Python port of selected CFDP utilities."""

--- a/python_cfdp/common/__init__.py
+++ b/python_cfdp/common/__init__.py
@@ -1,0 +1,23 @@
+"""Python translation of the CFDP common utilities."""
+
+from .bytes_util import (
+    read_integer,
+    encode_integer,
+    write_lv_string,
+    read_lv_string,
+    get_encoding_octets_nb,
+)
+from .cfdp_exception import CfdpException
+from .cfdp_runtime_exception import CfdpRuntimeException
+from .cfdp_standard_compliance_error import CfdpStandardComplianceError
+
+__all__ = [
+    "read_integer",
+    "encode_integer",
+    "write_lv_string",
+    "read_lv_string",
+    "get_encoding_octets_nb",
+    "CfdpException",
+    "CfdpRuntimeException",
+    "CfdpStandardComplianceError",
+]

--- a/python_cfdp/common/bytes_util.py
+++ b/python_cfdp/common/bytes_util.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for working with byte arrays.
+
+This module provides Python equivalents of the helper methods in
+`eu.dariolucia.ccsds.cfdp.common.BytesUtil`.
+"""
+from typing import Optional
+from .cfdp_runtime_exception import CfdpRuntimeException
+# Constants for get_encoding_octets_nb
+BYTE_LIMITS = [
+    (1, (256 ** 1) - 1),
+    (2, (256 ** 2) - 1),
+    (3, (256 ** 3) - 1),
+    (4, (256 ** 4) - 1),
+    (5, (256 ** 5) - 1),
+    (6, (256 ** 6) - 1),
+    (7, (256 ** 7) - 1),
+]
+
+
+def read_integer(data: bytes, offset: int, size: int) -> Optional[int]:
+    """Read an unsigned integer from ``data`` starting at ``offset``.
+
+    ``size`` specifies the number of bytes to read. When ``size`` is ``0`` a
+    ``None`` value is returned.
+    """
+    if size > 8:
+        raise CfdpRuntimeException(
+            f"Cannot read an unsigned integer larger than 8, actual is {size}")
+    if size < 0:
+        raise CfdpRuntimeException(
+            f"Cannot read an unsigned integer with a negative size, actual is {size}")
+    if size == 0:
+        return None
+    value = 0
+    for i in range(size):
+        value <<= 8
+        value |= data[offset + i] & 0xFF
+    return value
+
+
+def encode_integer(value: int, size: int) -> bytes:
+    """Encode ``value`` to ``size`` bytes using big endian order."""
+    if size > 8:
+        raise CfdpRuntimeException(
+            f"Cannot encode an unsigned integer larger than 8, actual is {size}")
+    if size < 0:
+        raise CfdpRuntimeException(
+            f"Cannot encode an unsigned integer with a negative size, actual is {size}")
+    output = bytearray(size)
+    mask = 0xFF
+    for i in range(size):
+        output[size - 1 - i] = (value & mask) >> (8 * i)
+        mask <<= 8
+    return bytes(output)
+
+
+def write_lv_string(buf: bytearray, string: Optional[str]) -> None:
+    """Write a LV (length-value) string to ``buf`` using ASCII encoding."""
+    if string and len(string) > 255:
+        raise ValueError(
+            f"String length is greater than 255, cannot write LV string: {string}")
+    if string:
+        buf.append(len(string) & 0xFF)
+        buf.extend(string.encode('ascii'))
+    else:
+        buf.append(0)
+
+
+def read_lv_string(data: bytes, offset: int) -> str:
+    """Read a LV (length-value) string from ``data`` starting at ``offset``."""
+    length = data[offset] & 0xFF
+    if length:
+        return data[offset + 1: offset + 1 + length].decode('ascii')
+    return ""
+
+
+def get_encoding_octets_nb(max_value: int) -> int:
+    """Return the minimum number of bytes required to encode ``max_value``."""
+    if max_value < 0:
+        return 8
+    if max_value == 0:
+        return 1
+    for bytes_nb, limit in BYTE_LIMITS:
+        if max_value <= limit:
+            return bytes_nb
+    return 8

--- a/python_cfdp/common/cfdp_exception.py
+++ b/python_cfdp/common/cfdp_exception.py
@@ -1,0 +1,3 @@
+class CfdpException(Exception):
+    """Base checked exception used by the CFDP module."""
+    pass

--- a/python_cfdp/common/cfdp_runtime_exception.py
+++ b/python_cfdp/common/cfdp_runtime_exception.py
@@ -1,0 +1,3 @@
+class CfdpRuntimeException(RuntimeError):
+    """Base unchecked exception used by the CFDP module."""
+    pass

--- a/python_cfdp/common/cfdp_standard_compliance_error.py
+++ b/python_cfdp/common/cfdp_standard_compliance_error.py
@@ -1,0 +1,3 @@
+class CfdpStandardComplianceError(Exception):
+    """Raised when a clear violation of the CCSDS CFDP standard is detected."""
+    pass

--- a/python_cfdp/tests/test_bytes_util.py
+++ b/python_cfdp/tests/test_bytes_util.py
@@ -1,0 +1,30 @@
+import unittest
+
+from python_cfdp.common import (
+    read_integer,
+    encode_integer,
+    write_lv_string,
+    read_lv_string,
+    get_encoding_octets_nb,
+)
+
+class TestBytesUtil(unittest.TestCase):
+    def test_integer_roundtrip(self):
+        value = 0xABCD
+        enc = encode_integer(value, 2)
+        self.assertEqual(enc, b'\xab\xcd')
+        self.assertEqual(read_integer(enc, 0, 2), value)
+
+    def test_lv_string(self):
+        buf = bytearray()
+        write_lv_string(buf, "CFDP")
+        self.assertEqual(buf, b"\x04CFDP")
+        self.assertEqual(read_lv_string(bytes(buf), 0), "CFDP")
+
+    def test_encoding_octets(self):
+        self.assertEqual(get_encoding_octets_nb(0), 1)
+        self.assertEqual(get_encoding_octets_nb(255), 1)
+        self.assertEqual(get_encoding_octets_nb(256), 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new `python_cfdp` package
- implement Python version of common CFDP utilities
- provide simple unit tests

## Testing
- `python3 -m unittest python_cfdp/tests/test_bytes_util.py`


------
https://chatgpt.com/codex/tasks/task_e_6841c71abe24833298a54a7d792a4334